### PR TITLE
feat(kube-prometheus-rules): add workload, kube-api, target, and node load alert rules — v0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,14 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        if: "steps.list-changed.outputs.changed == 'true' && ! contains(env.commitmsg, '[skip install]')"
+        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.7.0
 
+      - name: Install prometheus-operator CRDs
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.75.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+
       - name: Run chart-testing (install)
-        if: "steps.list-changed.outputs.changed == 'true' && ! contains(env.commitmsg, '[skip install]')"
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,10 @@ jobs:
         run: |
           kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.75.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 
+      - name: Create required namespaces
+        if: steps.list-changed.outputs.changed == 'true'
+        run: kubectl create namespace jx-observability --dry-run=client -o yaml | kubectl apply -f -
+
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -4,3 +4,5 @@ description: Community-inspired Prometheus alerting rules for Kubernetes observa
 type: application
 version: 0.4.0
 appVersion: "1.0.0"
+maintainers:
+  - name: lop3z

--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "1.0.0"

--- a/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
@@ -1,0 +1,165 @@
+{{- if .Values.rules.kubeApi.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-kube-api
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-prometheus-rules.labels" . | nindent 4 }}
+    gitops.jenkins-x.io/pipeline: namespaces
+spec:
+  groups:
+  - name: kubernetes.api
+    rules:
+    - alert: KubeAPILatencyHigh
+      annotations:
+        description: >
+          Kubernetes API server p99 latency for {{ "{{" }} $labels.verb {{ "}}" }}
+          {{ "{{" }} $labels.resource {{ "}}" }} is {{ "{{" }} printf "%.2f" $value {{ "}}" }}s
+          on cluster {{ .Values.clusterRegion }}.
+        summary: Kubernetes API server p99 latency high ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapilatencyhigh
+      expr: |-
+        histogram_quantile(0.99,
+          sum by (verb, resource, le) (
+            rate(apiserver_request_duration_seconds_bucket{
+              verb!~"WATCH|CONNECT"
+            }[5m])
+          )
+        ) > {{ .Values.rules.kubeApi.latencyWarningSeconds }}
+      for: 5m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeAPILatencyHigh
+      annotations:
+        description: >
+          Kubernetes API server p99 latency for {{ "{{" }} $labels.verb {{ "}}" }}
+          {{ "{{" }} $labels.resource {{ "}}" }} is {{ "{{" }} printf "%.2f" $value {{ "}}" }}s
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Kubernetes API server p99 latency critical ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapilatencyhigh
+      expr: |-
+        histogram_quantile(0.99,
+          sum by (verb, resource, le) (
+            rate(apiserver_request_duration_seconds_bucket{
+              verb!~"WATCH|CONNECT"
+            }[5m])
+          )
+        ) > {{ .Values.rules.kubeApi.latencyCriticalSeconds }}
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeAPIErrorRatioHigh
+      annotations:
+        description: >
+          Kubernetes API server error ratio is {{ "{{" }} printf "%.2f" $value {{ "}}" }}%
+          on cluster {{ .Values.clusterRegion }}.
+        summary: Kubernetes API server error ratio high ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorstoohigh
+      expr: |-
+        (
+          sum(rate(apiserver_request_total{code=~"5.."}[5m]))
+          /
+          sum(rate(apiserver_request_total[5m]))
+        ) * 100 > {{ .Values.rules.kubeApi.errorRatioWarning }}
+      for: 5m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeAPIErrorRatioHigh
+      annotations:
+        description: >
+          Kubernetes API server error ratio is {{ "{{" }} printf "%.2f" $value {{ "}}" }}%
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Kubernetes API server error ratio critical ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorstoohigh
+      expr: |-
+        (
+          sum(rate(apiserver_request_total{code=~"5.."}[5m]))
+          /
+          sum(rate(apiserver_request_total[5m]))
+        ) * 100 > {{ .Values.rules.kubeApi.errorRatioCritical }}
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeJobFailed
+      annotations:
+        description: >
+          Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }}
+          has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
+        summary: Kubernetes Job has failures ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+      expr: |-
+        sum by (namespace, job_name, cluster_region) (
+          increase(kube_job_status_failed{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }[30m])
+        ) >= {{ .Values.rules.kubeApi.jobFailedWarning }}
+      for: 0m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeJobFailed
+      annotations:
+        description: >
+          Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }}
+          has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Kubernetes Job has critical failures ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+      expr: |-
+        sum by (namespace, job_name, cluster_region) (
+          increase(kube_job_status_failed{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }[30m])
+        ) >= {{ .Values.rules.kubeApi.jobFailedCritical }}
+      for: 0m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeCronJobMissedSchedule
+      annotations:
+        description: >
+          CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.cronjob {{ "}}" }}
+          has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
+          on cluster {{ .Values.clusterRegion }}.
+        summary: CronJob missed schedule ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecronjobrunning
+      expr: |-
+        time() - kube_cronjob_status_last_schedule_time{
+          cluster_region="{{ .Values.clusterRegion }}"
+        } > {{ .Values.rules.kubeApi.cronJobMissedWarningSeconds }}
+      for: 0m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeCronJobMissedSchedule
+      annotations:
+        description: >
+          CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.cronjob {{ "}}" }}
+          has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: CronJob missed schedule critically overdue ({{ .Values.clusterRegion }})
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecronjobrunning
+      expr: |-
+        time() - kube_cronjob_status_last_schedule_time{
+          cluster_region="{{ .Values.clusterRegion }}"
+        } > {{ .Values.rules.kubeApi.cronJobMissedCriticalSeconds }}
+      for: 0m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+{{- end }}

--- a/charts/kube-prometheus-rules/templates/node-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/node-rules.yaml
@@ -247,4 +247,49 @@ spec:
       labels:
         severity: warning
         cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeNodeLoadHigh
+      annotations:
+        description: >
+          Node {{ "{{" }} $labels.instance {{ "}}" }} normalized load is
+          {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
+        summary: Node load saturation high ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          node_load5{cluster_region="{{ .Values.clusterRegion }}"}
+          /
+          count by (instance, cluster_region) (
+            node_cpu_seconds_total{
+              mode="idle",
+              cluster_region="{{ .Values.clusterRegion }}"
+            }
+          )
+        ) > {{ .Values.rules.node.loadWarningRatio }}
+      for: 10m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeNodeLoadHigh
+      annotations:
+        description: >
+          Node {{ "{{" }} $labels.instance {{ "}}" }} normalized load is
+          {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Node load critically saturated ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          node_load5{cluster_region="{{ .Values.clusterRegion }}"}
+          /
+          count by (instance, cluster_region) (
+            node_cpu_seconds_total{
+              mode="idle",
+              cluster_region="{{ .Values.clusterRegion }}"
+            }
+          )
+        ) > {{ .Values.rules.node.loadCriticalRatio }}
+      for: 10m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
 {{- end }}

--- a/charts/kube-prometheus-rules/templates/pvc-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/pvc-rules.yaml
@@ -130,4 +130,41 @@ spec:
       labels:
         severity: critical
         cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubePersistentVolumeGrowthAbnormal
+      annotations:
+        description: >
+          PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
+          is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
+        summary: PVC daily growth rate abnormal ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          deriv(kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}[1d])
+          * 86400
+          / kubelet_volume_stats_capacity_bytes{cluster_region="{{ .Values.clusterRegion }}"}
+          * 100
+        ) > {{ .Values.rules.pvc.growthRateWarning }}
+      for: 1h
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubePersistentVolumeGrowthAbnormal
+      annotations:
+        description: >
+          PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
+          is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: PVC daily growth rate critically high ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          deriv(kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}[1d])
+          * 86400
+          / kubelet_volume_stats_capacity_bytes{cluster_region="{{ .Values.clusterRegion }}"}
+          * 100
+        ) > {{ .Values.rules.pvc.growthRateCritical }}
+      for: 1h
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
 {{- end }}

--- a/charts/kube-prometheus-rules/templates/target-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/target-rules.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.rules.targets.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-targets
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-prometheus-rules.labels" . | nindent 4 }}
+    gitops.jenkins-x.io/pipeline: namespaces
+spec:
+  groups:
+  - name: kubernetes.targets
+    rules:
+    - alert: KubeScrapeTargetDown
+      annotations:
+        description: >
+          Scrape target {{ "{{" }} $labels.job {{ "}}" }} instance {{ "{{" }} $labels.instance {{ "}}" }}
+          is down on cluster {{ .Values.clusterRegion }}.
+        summary: Scrape target down ({{ .Values.clusterRegion }})
+      expr: |-
+        up{cluster_region="{{ .Values.clusterRegion }}"} == 0
+      for: 2m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeScrapeTargetDown
+      annotations:
+        description: >
+          Scrape target {{ "{{" }} $labels.job {{ "}}" }} instance {{ "{{" }} $labels.instance {{ "}}" }}
+          has been down for 5m on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Scrape target persistently down ({{ .Values.clusterRegion }})
+      expr: |-
+        up{cluster_region="{{ .Values.clusterRegion }}"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeScrapeErrorRatioHigh
+      annotations:
+        description: >
+          {{ "{{" }} printf "%.1f" $value {{ "}}" }}% of scrape targets are down
+          on cluster {{ .Values.clusterRegion }}.
+        summary: High scrape error ratio ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          count(up{cluster_region="{{ .Values.clusterRegion }}"} == 0)
+          /
+          count(up{cluster_region="{{ .Values.clusterRegion }}"})
+        ) * 100 > {{ .Values.rules.targets.scrapeErrorRatioWarning }}
+      for: 5m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeScrapeErrorRatioHigh
+      annotations:
+        description: >
+          {{ "{{" }} printf "%.1f" $value {{ "}}" }}% of scrape targets are down
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Critical scrape error ratio ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          count(up{cluster_region="{{ .Values.clusterRegion }}"} == 0)
+          /
+          count(up{cluster_region="{{ .Values.clusterRegion }}"})
+        ) * 100 > {{ .Values.rules.targets.scrapeErrorRatioCritical }}
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeHAProxyBackendDown
+      annotations:
+        description: >
+          HAProxy backend {{ "{{" }} $labels.proxy {{ "}}" }} is down
+          on cluster {{ .Values.clusterRegion }}.
+        summary: HAProxy backend down ({{ .Values.clusterRegion }})
+      expr: |-
+        haproxy_backend_status{
+          status="DOWN",
+          cluster_region="{{ .Values.clusterRegion }}"
+        } == 1
+      for: 2m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeHAProxyBackendDown
+      annotations:
+        description: >
+          HAProxy backend {{ "{{" }} $labels.proxy {{ "}}" }} has been down for 5m
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: HAProxy backend persistently down ({{ .Values.clusterRegion }})
+      expr: |-
+        haproxy_backend_status{
+          status="DOWN",
+          cluster_region="{{ .Values.clusterRegion }}"
+        } == 1
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeMongoDBExporterDown
+      annotations:
+        description: >
+          MongoDB exporter instance {{ "{{" }} $labels.instance {{ "}}" }} is down
+          on cluster {{ .Values.clusterRegion }}.
+        summary: MongoDB exporter down ({{ .Values.clusterRegion }})
+      expr: |-
+        mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0
+      for: 2m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeMongoDBExporterDown
+      annotations:
+        description: >
+          MongoDB exporter instance {{ "{{" }} $labels.instance {{ "}}" }} has been down for 5m
+          on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: MongoDB exporter persistently down ({{ .Values.clusterRegion }})
+      expr: |-
+        mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+{{- end }}

--- a/charts/kube-prometheus-rules/templates/workload-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/workload-rules.yaml
@@ -1,0 +1,202 @@
+{{- if .Values.rules.workload.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-workload
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-prometheus-rules.labels" . | nindent 4 }}
+    gitops.jenkins-x.io/pipeline: namespaces
+spec:
+  groups:
+  - name: kubernetes.workload
+    rules:
+    - alert: KubePodRestartSpike
+      annotations:
+        description: >
+          Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }}
+          container {{ "{{" }} $labels.container {{ "}}" }} restarted
+          {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
+        summary: Pod restart spike detected ({{ .Values.clusterRegion }})
+      expr: |-
+        increase(kube_pod_container_status_restarts_total{
+          cluster_region="{{ .Values.clusterRegion }}"
+        }[15m]) > {{ .Values.rules.workload.podRestartWarningThreshold }}
+      for: 0m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubePodRestartSpike
+      annotations:
+        description: >
+          Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }}
+          container {{ "{{" }} $labels.container {{ "}}" }} restarted
+          {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Pod restart spike critical ({{ .Values.clusterRegion }})
+      expr: |-
+        increase(kube_pod_container_status_restarts_total{
+          cluster_region="{{ .Values.clusterRegion }}"
+        }[15m]) > {{ .Values.rules.workload.podRestartCriticalThreshold }}
+      for: 0m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubePodNotReadyRatioHigh
+      annotations:
+        description: >
+          {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of pods in namespace
+          {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
+        summary: High pod not-ready ratio ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          count by (namespace, cluster_region) (
+            kube_pod_status_ready{
+              condition="false",
+              cluster_region="{{ .Values.clusterRegion }}"
+            } == 1
+          )
+          /
+          count by (namespace, cluster_region) (
+            kube_pod_status_ready{
+              cluster_region="{{ .Values.clusterRegion }}"
+            }
+          )
+        ) * 100 > {{ .Values.rules.workload.podNotReadyWarningThreshold }}
+      for: 10m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubePodNotReadyRatioHigh
+      annotations:
+        description: >
+          {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of pods in namespace
+          {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Critical pod not-ready ratio ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          count by (namespace, cluster_region) (
+            kube_pod_status_ready{
+              condition="false",
+              cluster_region="{{ .Values.clusterRegion }}"
+            } == 1
+          )
+          /
+          count by (namespace, cluster_region) (
+            kube_pod_status_ready{
+              cluster_region="{{ .Values.clusterRegion }}"
+            }
+          )
+        ) * 100 > {{ .Values.rules.workload.podNotReadyCriticalThreshold }}
+      for: 10m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeWorkloadUnavailableRatioHigh
+      annotations:
+        description: >
+          Deployment {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.deployment {{ "}}" }}
+          has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
+        summary: Workload unavailable replica ratio high ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          kube_deployment_status_replicas_unavailable{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+          /
+          kube_deployment_status_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+        ) * 100 > {{ .Values.rules.workload.workloadUnavailableWarningThreshold }}
+      for: 10m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeWorkloadUnavailableRatioHigh
+      annotations:
+        description: >
+          Deployment {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.deployment {{ "}}" }}
+          has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: Workload unavailable replica ratio critical ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          kube_deployment_status_replicas_unavailable{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+          /
+          kube_deployment_status_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+        ) * 100 > {{ .Values.rules.workload.workloadUnavailableCriticalThreshold }}
+      for: 10m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeHPAMaxedReplicas
+      annotations:
+        description: >
+          HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
+          is at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of max replicas on cluster {{ .Values.clusterRegion }}.
+        summary: HPA near maximum replicas ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          kube_horizontalpodautoscaler_status_current_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+          /
+          kube_horizontalpodautoscaler_spec_max_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+        ) * 100 >= {{ .Values.rules.workload.hpaMaxedWarningRatio }}
+      for: 10m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeHPAMaxedReplicas
+      annotations:
+        description: >
+          HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
+          has reached maximum replicas on cluster {{ .Values.clusterRegion }}.
+          Immediate action required.
+        summary: HPA at maximum replicas ({{ .Values.clusterRegion }})
+      expr: |-
+        (
+          kube_horizontalpodautoscaler_status_current_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+          /
+          kube_horizontalpodautoscaler_spec_max_replicas{
+            cluster_region="{{ .Values.clusterRegion }}"
+          }
+        ) * 100 >= {{ .Values.rules.workload.hpaMaxedCriticalRatio }}
+      for: 10m
+      labels:
+        severity: critical
+        cluster_region: {{ .Values.clusterRegion }}
+
+    - alert: KubeHPAScalingLimited
+      annotations:
+        description: >
+          HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
+          scaling is limited or failing on cluster {{ .Values.clusterRegion }}.
+        summary: HPA scaling limited or failing ({{ .Values.clusterRegion }})
+      expr: |-
+        kube_horizontalpodautoscaler_status_condition{
+          condition="ScalingLimited",
+          status="true",
+          cluster_region="{{ .Values.clusterRegion }}"
+        } == 1
+      for: 5m
+      labels:
+        severity: warning
+        cluster_region: {{ .Values.clusterRegion }}
+{{- end }}

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -17,6 +17,9 @@ rules:
     inodeCriticalThreshold: 85
     # Warning: PVC predicted to be full within this many hours
     predictFullInHours: 96
+    # PVC daily growth rate thresholds (%)
+    growthRateWarning: 10
+    growthRateCritical: 20
 
   node:
     enabled: true
@@ -32,3 +35,42 @@ rules:
     # Root filesystem inode usage thresholds (%)
     inodeWarningThreshold: 85
     inodeCriticalThreshold: 95
+    # Normalized load (load5 / cpu_count) thresholds
+    loadWarningRatio: 1.20
+    loadCriticalRatio: 1.50
+
+  workload:
+    enabled: true
+    # Pod restart spike thresholds (count in 15m)
+    podRestartWarningThreshold: 5
+    podRestartCriticalThreshold: 10
+    # Pod not-ready ratio thresholds (%)
+    podNotReadyWarningThreshold: 10
+    podNotReadyCriticalThreshold: 30
+    # Deployment unavailable replica ratio thresholds (%)
+    workloadUnavailableWarningThreshold: 10
+    workloadUnavailableCriticalThreshold: 30
+    # HPA maxed replicas thresholds (%)
+    hpaMaxedWarningRatio: 90
+    hpaMaxedCriticalRatio: 100
+
+  kubeApi:
+    enabled: true
+    # API server p99 latency thresholds (seconds)
+    latencyWarningSeconds: 1.0
+    latencyCriticalSeconds: 2.0
+    # API server 5xx error ratio thresholds (%)
+    errorRatioWarning: 3
+    errorRatioCritical: 10
+    # Job failure thresholds (count in 30m)
+    jobFailedWarning: 1
+    jobFailedCritical: 3
+    # CronJob missed schedule thresholds (seconds since last schedule)
+    cronJobMissedWarningSeconds: 1800
+    cronJobMissedCriticalSeconds: 3600
+
+  targets:
+    enabled: true
+    # Scrape error ratio thresholds (% of targets down)
+    scrapeErrorRatioWarning: 5
+    scrapeErrorRatioCritical: 20


### PR DESCRIPTION
Add workload, kube-api, target, and node load PrometheusRule alert groups to kube-prometheus-rules chart.