### PR TITLE
feat(kube-prometheus-rules): make runbook URLs configurable via values (v0.7.0)

### DIFF
--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.0.0"
 maintainers:
   - name: lop3z

--- a/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
@@ -18,7 +18,9 @@ spec:
           {{ "{{" }} $labels.resource {{ "}}" }} is {{ "{{" }} printf "%.2f" $value {{ "}}" }}s
           on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes API server p99 latency high ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapilatencyhigh
+        {{- if .Values.runbooks.kubeApi.latencyHigh }}
+        runbook_url: {{ .Values.runbooks.kubeApi.latencyHigh }}
+        {{- end }}
       expr: |-
         histogram_quantile(0.99,
           sum by (verb, resource, le) (
@@ -40,7 +42,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes API server p99 latency critical ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapilatencyhigh
+        {{- if .Values.runbooks.kubeApi.latencyHigh }}
+        runbook_url: {{ .Values.runbooks.kubeApi.latencyHigh }}
+        {{- end }}
       expr: |-
         histogram_quantile(0.99,
           sum by (verb, resource, le) (
@@ -60,7 +64,9 @@ spec:
           Kubernetes API server error ratio is {{ "{{" }} printf "%.2f" $value {{ "}}" }}%
           on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes API server error ratio high ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorstoohigh
+        {{- if .Values.runbooks.kubeApi.errorRatioHigh }}
+        runbook_url: {{ .Values.runbooks.kubeApi.errorRatioHigh }}
+        {{- end }}
       expr: |-
         (
           sum(rate(apiserver_request_total{code=~"5.."}[5m]))
@@ -79,7 +85,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes API server error ratio critical ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorstoohigh
+        {{- if .Values.runbooks.kubeApi.errorRatioHigh }}
+        runbook_url: {{ .Values.runbooks.kubeApi.errorRatioHigh }}
+        {{- end }}
       expr: |-
         (
           sum(rate(apiserver_request_total{code=~"5.."}[5m]))
@@ -97,7 +105,9 @@ spec:
           Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }}
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes Job has failures ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+        {{- if .Values.runbooks.kubeApi.jobFailed }}
+        runbook_url: {{ .Values.runbooks.kubeApi.jobFailed }}
+        {{- end }}
       expr: |-
         sum by (namespace, job_name, cluster_region) (
           increase(kube_job_status_failed{
@@ -116,7 +126,9 @@ spec:
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes Job has critical failures ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+        {{- if .Values.runbooks.kubeApi.jobFailed }}
+        runbook_url: {{ .Values.runbooks.kubeApi.jobFailed }}
+        {{- end }}
       expr: |-
         sum by (namespace, job_name, cluster_region) (
           increase(kube_job_status_failed{
@@ -135,7 +147,9 @@ spec:
           has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
           on cluster {{ .Values.clusterRegion }}.
         summary: CronJob missed schedule ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecronjobrunning
+        {{- if .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        runbook_url: {{ .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        {{- end }}
       expr: |-
         time() - kube_cronjob_status_last_schedule_time{
           cluster_region="{{ .Values.clusterRegion }}"
@@ -153,7 +167,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: CronJob missed schedule critically overdue ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecronjobrunning
+        {{- if .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        runbook_url: {{ .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        {{- end }}
       expr: |-
         time() - kube_cronjob_status_last_schedule_time{
           cluster_region="{{ .Values.clusterRegion }}"

--- a/charts/kube-prometheus-rules/templates/node-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/node-rules.yaml
@@ -17,6 +17,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} memory usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node memory usage high ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.memoryHigh }}
+        runbook_url: {{ .Values.runbooks.node.memoryHigh }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -36,6 +39,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node memory critically high ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.memoryHigh }}
+        runbook_url: {{ .Values.runbooks.node.memoryHigh }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -54,6 +60,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} CPU usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node CPU saturation ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.cpuSaturation }}
+        runbook_url: {{ .Values.runbooks.node.cpuSaturation }}
+        {{- end }}
       expr: |-
         (
           1 - avg by (instance, cluster_region) (
@@ -75,6 +84,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node CPU critically saturated ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.cpuSaturation }}
+        runbook_url: {{ .Values.runbooks.node.cpuSaturation }}
+        {{- end }}
       expr: |-
         (
           1 - avg by (instance, cluster_region) (
@@ -95,7 +107,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem almost full ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutofspace
+        {{- if .Values.runbooks.node.filesystemAlmostFull }}
+        runbook_url: {{ .Values.runbooks.node.filesystemAlmostFull }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -123,7 +137,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node root filesystem critically full ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutofspace
+        {{- if .Values.runbooks.node.filesystemAlmostFull }}
+        runbook_url: {{ .Values.runbooks.node.filesystemAlmostFull }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -150,6 +166,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} inode usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem inode saturation ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.inodesSaturation }}
+        runbook_url: {{ .Values.runbooks.node.inodesSaturation }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -177,6 +196,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node root filesystem inodes critically saturated ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.inodesSaturation }}
+        runbook_url: {{ .Values.runbooks.node.inodesSaturation }}
+        {{- end }}
       expr: |-
         (
           1 - (
@@ -203,7 +225,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem is predicted to fill up
           within 24 hours on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem predicted to be full in 24h ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemspacefillingup
+        {{- if .Values.runbooks.node.filesystemSpaceFillingUp }}
+        runbook_url: {{ .Values.runbooks.node.filesystemSpaceFillingUp }}
+        {{- end }}
       expr: |-
         (
           node_filesystem_avail_bytes{
@@ -236,7 +260,9 @@ spec:
           Node {{ "{{" }} $labels.node {{ "}}" }} has {{ "{{" }} $labels.condition {{ "}}" }}
           pressure on cluster {{ .Values.clusterRegion }}.
         summary: Node pressure condition active ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodepressure
+        {{- if .Values.runbooks.node.pressure }}
+        runbook_url: {{ .Values.runbooks.node.pressure }}
+        {{- end }}
       expr: |-
         kube_node_status_condition{
           condition=~"MemoryPressure|DiskPressure|PIDPressure",
@@ -254,6 +280,9 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} normalized load is
           {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
         summary: Node load saturation high ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.loadHigh }}
+        runbook_url: {{ .Values.runbooks.node.loadHigh }}
+        {{- end }}
       expr: |-
         (
           node_load5{cluster_region="{{ .Values.clusterRegion }}"}
@@ -277,6 +306,9 @@ spec:
           {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node load critically saturated ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.node.loadHigh }}
+        runbook_url: {{ .Values.runbooks.node.loadHigh }}
+        {{- end }}
       expr: |-
         (
           node_load5{cluster_region="{{ .Values.clusterRegion }}"}

--- a/charts/kube-prometheus-rules/templates/pvc-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/pvc-rules.yaml
@@ -17,7 +17,9 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
         summary: PVC is almost full ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+        {{- if .Values.runbooks.pvc.fillingUp }}
+        runbook_url: {{ .Values.runbooks.pvc.fillingUp }}
+        {{- end }}
       expr: |-
         (
           kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}
@@ -36,7 +38,9 @@ spec:
           is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC is critically full ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+        {{- if .Values.runbooks.pvc.fillingUp }}
+        runbook_url: {{ .Values.runbooks.pvc.fillingUp }}
+        {{- end }}
       expr: |-
         (
           kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}
@@ -54,7 +58,9 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           inode usage is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: PVC inodes almost exhausted ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumeinodesfillingup
+        {{- if .Values.runbooks.pvc.inodesFillingUp }}
+        runbook_url: {{ .Values.runbooks.pvc.inodesFillingUp }}
+        {{- end }}
       expr: |-
         (
           kubelet_volume_stats_inodes_used{cluster_region="{{ .Values.clusterRegion }}"}
@@ -76,7 +82,9 @@ spec:
           inode usage is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC inodes critically exhausted ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumeinodesfillingup
+        {{- if .Values.runbooks.pvc.inodesFillingUp }}
+        runbook_url: {{ .Values.runbooks.pvc.inodesFillingUp }}
+        {{- end }}
       expr: |-
         (
           kubelet_volume_stats_inodes_used{cluster_region="{{ .Values.clusterRegion }}"}
@@ -97,7 +105,9 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is predicted to fill up within {{ .Values.rules.pvc.predictFullInHours }} hours on cluster {{ .Values.clusterRegion }}.
         summary: PVC predicted to be full in {{ .Values.rules.pvc.predictFullInHours }}h ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+        {{- if .Values.runbooks.pvc.fillingUpPredicted }}
+        runbook_url: {{ .Values.runbooks.pvc.fillingUpPredicted }}
+        {{- end }}
       expr: |-
         (
           kubelet_volume_stats_available_bytes{cluster_region="{{ .Values.clusterRegion }}"}
@@ -120,7 +130,9 @@ spec:
           PVC {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} is in {{ "{{" }} $labels.phase {{ "}}" }}
           phase on cluster {{ .Values.clusterRegion }}.
         summary: PVC in Failed or Pending state ({{ .Values.clusterRegion }})
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumeerrors
+        {{- if .Values.runbooks.pvc.errors }}
+        runbook_url: {{ .Values.runbooks.pvc.errors }}
+        {{- end }}
       expr: |-
         kube_persistentvolume_status_phase{
           phase=~"Failed|Pending",
@@ -137,6 +149,9 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
         summary: PVC daily growth rate abnormal ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.pvc.growthAbnormal }}
+        runbook_url: {{ .Values.runbooks.pvc.growthAbnormal }}
+        {{- end }}
       expr: |-
         (
           deriv(kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}[1d])
@@ -156,6 +171,9 @@ spec:
           is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC daily growth rate critically high ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.pvc.growthAbnormal }}
+        runbook_url: {{ .Values.runbooks.pvc.growthAbnormal }}
+        {{- end }}
       expr: |-
         (
           deriv(kubelet_volume_stats_used_bytes{cluster_region="{{ .Values.clusterRegion }}"}[1d])

--- a/charts/kube-prometheus-rules/templates/target-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/target-rules.yaml
@@ -17,6 +17,9 @@ spec:
           Scrape target {{ "{{" }} $labels.job {{ "}}" }} instance {{ "{{" }} $labels.instance {{ "}}" }}
           is down on cluster {{ .Values.clusterRegion }}.
         summary: Scrape target down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.scrapeTargetDown }}
+        runbook_url: {{ .Values.runbooks.targets.scrapeTargetDown }}
+        {{- end }}
       expr: |-
         up{cluster_region="{{ .Values.clusterRegion }}"} == 0
       for: 2m
@@ -31,6 +34,9 @@ spec:
           has been down for 5m on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Scrape target persistently down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.scrapeTargetDown }}
+        runbook_url: {{ .Values.runbooks.targets.scrapeTargetDown }}
+        {{- end }}
       expr: |-
         up{cluster_region="{{ .Values.clusterRegion }}"} == 0
       for: 5m
@@ -44,6 +50,9 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}% of scrape targets are down
           on cluster {{ .Values.clusterRegion }}.
         summary: High scrape error ratio ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.scrapeErrorRatio }}
+        runbook_url: {{ .Values.runbooks.targets.scrapeErrorRatio }}
+        {{- end }}
       expr: |-
         (
           count(up{cluster_region="{{ .Values.clusterRegion }}"} == 0)
@@ -62,6 +71,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Critical scrape error ratio ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.scrapeErrorRatio }}
+        runbook_url: {{ .Values.runbooks.targets.scrapeErrorRatio }}
+        {{- end }}
       expr: |-
         (
           count(up{cluster_region="{{ .Values.clusterRegion }}"} == 0)
@@ -79,6 +91,9 @@ spec:
           HAProxy backend {{ "{{" }} $labels.proxy {{ "}}" }} is down
           on cluster {{ .Values.clusterRegion }}.
         summary: HAProxy backend down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.haproxyBackendDown }}
+        runbook_url: {{ .Values.runbooks.targets.haproxyBackendDown }}
+        {{- end }}
       expr: |-
         haproxy_backend_status{
           status="DOWN",
@@ -96,6 +111,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: HAProxy backend persistently down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.haproxyBackendDown }}
+        runbook_url: {{ .Values.runbooks.targets.haproxyBackendDown }}
+        {{- end }}
       expr: |-
         haproxy_backend_status{
           status="DOWN",
@@ -112,6 +130,9 @@ spec:
           MongoDB exporter instance {{ "{{" }} $labels.instance {{ "}}" }} is down
           on cluster {{ .Values.clusterRegion }}.
         summary: MongoDB exporter down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.mongodbExporterDown }}
+        runbook_url: {{ .Values.runbooks.targets.mongodbExporterDown }}
+        {{- end }}
       expr: |-
         mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0
       for: 2m
@@ -126,6 +147,9 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: MongoDB exporter persistently down ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.targets.mongodbExporterDown }}
+        runbook_url: {{ .Values.runbooks.targets.mongodbExporterDown }}
+        {{- end }}
       expr: |-
         mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0
       for: 5m

--- a/charts/kube-prometheus-rules/templates/velero-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/velero-rules.yaml
@@ -18,6 +18,9 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}h ago on cluster {{ .Values.clusterRegion }}.
           Backup may have been skipped or failed.
         summary: Velero backup stale ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.velero.backupStale }}
+        runbook_url: {{ .Values.runbooks.velero.backupStale }}
+        {{- end }}
       expr: |-
         (
           time() - velero_backup_last_successful_timestamp{
@@ -37,6 +40,9 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}h ago on cluster {{ .Values.clusterRegion }}.
           Immediate action required — multiple consecutive backup runs may have failed.
         summary: Velero backup critically stale ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.velero.backupStale }}
+        runbook_url: {{ .Values.runbooks.velero.backupStale }}
+        {{- end }}
       expr: |-
         (
           time() - velero_backup_last_successful_timestamp{

--- a/charts/kube-prometheus-rules/templates/workload-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/workload-rules.yaml
@@ -18,6 +18,9 @@ spec:
           container {{ "{{" }} $labels.container {{ "}}" }} restarted
           {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
         summary: Pod restart spike detected ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.podRestartSpike }}
+        runbook_url: {{ .Values.runbooks.workload.podRestartSpike }}
+        {{- end }}
       expr: |-
         increase(kube_pod_container_status_restarts_total{
           cluster_region="{{ .Values.clusterRegion }}"
@@ -35,6 +38,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Pod restart spike critical ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.podRestartSpike }}
+        runbook_url: {{ .Values.runbooks.workload.podRestartSpike }}
+        {{- end }}
       expr: |-
         increase(kube_pod_container_status_restarts_total{
           cluster_region="{{ .Values.clusterRegion }}"
@@ -50,6 +56,9 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of pods in namespace
           {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
         summary: High pod not-ready ratio ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.podNotReady }}
+        runbook_url: {{ .Values.runbooks.workload.podNotReady }}
+        {{- end }}
       expr: |-
         (
           count by (namespace, cluster_region) (
@@ -77,6 +86,9 @@ spec:
           {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Critical pod not-ready ratio ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.podNotReady }}
+        runbook_url: {{ .Values.runbooks.workload.podNotReady }}
+        {{- end }}
       expr: |-
         (
           count by (namespace, cluster_region) (
@@ -103,6 +115,9 @@ spec:
           Deployment {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.deployment {{ "}}" }}
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
         summary: Workload unavailable replica ratio high ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.workloadUnavailable }}
+        runbook_url: {{ .Values.runbooks.workload.workloadUnavailable }}
+        {{- end }}
       expr: |-
         (
           kube_deployment_status_replicas_unavailable{
@@ -125,6 +140,9 @@ spec:
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Workload unavailable replica ratio critical ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.workloadUnavailable }}
+        runbook_url: {{ .Values.runbooks.workload.workloadUnavailable }}
+        {{- end }}
       expr: |-
         (
           kube_deployment_status_replicas_unavailable{
@@ -146,6 +164,9 @@ spec:
           HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
           is at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of max replicas on cluster {{ .Values.clusterRegion }}.
         summary: HPA near maximum replicas ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.hpaMaxedReplicas }}
+        runbook_url: {{ .Values.runbooks.workload.hpaMaxedReplicas }}
+        {{- end }}
       expr: |-
         (
           kube_horizontalpodautoscaler_status_current_replicas{
@@ -168,6 +189,9 @@ spec:
           has reached maximum replicas on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: HPA at maximum replicas ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.hpaMaxedReplicas }}
+        runbook_url: {{ .Values.runbooks.workload.hpaMaxedReplicas }}
+        {{- end }}
       expr: |-
         (
           kube_horizontalpodautoscaler_status_current_replicas{
@@ -189,6 +213,9 @@ spec:
           HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
           scaling is limited or failing on cluster {{ .Values.clusterRegion }}.
         summary: HPA scaling limited or failing ({{ .Values.clusterRegion }})
+        {{- if .Values.runbooks.workload.hpaScalingLimited }}
+        runbook_url: {{ .Values.runbooks.workload.hpaScalingLimited }}
+        {{- end }}
       expr: |-
         kube_horizontalpodautoscaler_status_condition{
           condition="ScalingLimited",

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -87,3 +87,39 @@ rules:
     staleWarningHours: 25
     # Hours since last successful backup before critical (default: 49h — missed 2 consecutive runs)
     staleCriticalHours: 49
+
+# Runbook URLs for each alert — set to your internal Notion/Confluence pages in the version stream.
+# Leave empty ("") to omit the runbook_url annotation from the PrometheusRule.
+runbooks:
+  node:
+    memoryHigh: ""
+    cpuSaturation: ""
+    filesystemAlmostFull: ""
+    inodesSaturation: ""
+    filesystemSpaceFillingUp: ""
+    pressure: ""
+    loadHigh: ""
+  pvc:
+    fillingUp: ""
+    inodesFillingUp: ""
+    fillingUpPredicted: ""
+    errors: ""
+    growthAbnormal: ""
+  workload:
+    podRestartSpike: ""
+    podNotReady: ""
+    workloadUnavailable: ""
+    hpaMaxedReplicas: ""
+    hpaScalingLimited: ""
+  targets:
+    scrapeTargetDown: ""
+    scrapeErrorRatio: ""
+    haproxyBackendDown: ""
+    mongodbExporterDown: ""
+  kubeApi:
+    latencyHigh: ""
+    errorRatioHigh: ""
+    jobFailed: ""
+    cronJobMissedSchedule: ""
+  velero:
+    backupStale: ""


### PR DESCRIPTION
## Summary

- Add top-level `runbooks:` section to `values.yaml` with empty-string defaults for all alert families: `node`, `pvc`, `workload`, `targets`, `kubeApi`, `velero`
- All 6 PrometheusRule templates now emit `runbook_url` conditionally — only when the value is non-empty
- Removes all previously hardcoded `runbooks.prometheus-operator.dev` URLs from the public chart
- Runbook URLs (Notion pages) are set per-cluster in the version stream at `versionStream/charts/lop3z/kube-prometheus-rules/values.yaml.gotmpl`
- Bumps chart version `0.6.0` → `0.7.0`

## Version Stream Candidates

Runbook URL values should be added to `jx3-versions/charts/lop3z/kube-prometheus-rules/values.yaml.gotmpl` once Notion pages are created.

## Helm Chart Suggestions

None.

## Test Plan

- [ ] Merge and verify chart publishes at `0.7.0` via GitHub Pages
- [ ] Deploy to sbg5 dev — confirm PrometheusRule manifests render without `runbook_url` (all values empty by default)
- [ ] Add one Notion URL to sbg5 version stream, confirm it appears in the rendered PrometheusRule annotation