### PR TITLE
feat(kube-prometheus-rules): add runbooks.default fallback URL (v0.7.1)

### DIFF
--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "1.0.0"
 maintainers:
   - name: lop3z

--- a/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
@@ -18,8 +18,8 @@ spec:
           {{ "{{" }} $labels.resource {{ "}}" }} is {{ "{{" }} printf "%.2f" $value {{ "}}" }}s
           on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes API server p99 latency high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.latencyHigh }}
-        runbook_url: {{ .Values.runbooks.kubeApi.latencyHigh }}
+        {{- with (.Values.runbooks.kubeApi.latencyHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         histogram_quantile(0.99,
@@ -42,8 +42,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes API server p99 latency critical ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.latencyHigh }}
-        runbook_url: {{ .Values.runbooks.kubeApi.latencyHigh }}
+        {{- with (.Values.runbooks.kubeApi.latencyHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         histogram_quantile(0.99,
@@ -64,8 +64,8 @@ spec:
           Kubernetes API server error ratio is {{ "{{" }} printf "%.2f" $value {{ "}}" }}%
           on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes API server error ratio high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.errorRatioHigh }}
-        runbook_url: {{ .Values.runbooks.kubeApi.errorRatioHigh }}
+        {{- with (.Values.runbooks.kubeApi.errorRatioHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -85,8 +85,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes API server error ratio critical ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.errorRatioHigh }}
-        runbook_url: {{ .Values.runbooks.kubeApi.errorRatioHigh }}
+        {{- with (.Values.runbooks.kubeApi.errorRatioHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -105,8 +105,8 @@ spec:
           Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }}
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
         summary: Kubernetes Job has failures ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.jobFailed }}
-        runbook_url: {{ .Values.runbooks.kubeApi.jobFailed }}
+        {{- with (.Values.runbooks.kubeApi.jobFailed | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         sum by (namespace, job_name, cluster_region) (
@@ -126,8 +126,8 @@ spec:
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }} failed pods on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Kubernetes Job has critical failures ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.jobFailed }}
-        runbook_url: {{ .Values.runbooks.kubeApi.jobFailed }}
+        {{- with (.Values.runbooks.kubeApi.jobFailed | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         sum by (namespace, job_name, cluster_region) (
@@ -147,8 +147,8 @@ spec:
           has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
           on cluster {{ .Values.clusterRegion }}.
         summary: CronJob missed schedule ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.cronJobMissedSchedule }}
-        runbook_url: {{ .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        {{- with (.Values.runbooks.kubeApi.cronJobMissedSchedule | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         time() - kube_cronjob_status_last_schedule_time{
@@ -167,8 +167,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: CronJob missed schedule critically overdue ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.kubeApi.cronJobMissedSchedule }}
-        runbook_url: {{ .Values.runbooks.kubeApi.cronJobMissedSchedule }}
+        {{- with (.Values.runbooks.kubeApi.cronJobMissedSchedule | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         time() - kube_cronjob_status_last_schedule_time{

--- a/charts/kube-prometheus-rules/templates/node-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/node-rules.yaml
@@ -17,8 +17,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} memory usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node memory usage high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.memoryHigh }}
-        runbook_url: {{ .Values.runbooks.node.memoryHigh }}
+        {{- with (.Values.runbooks.node.memoryHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -39,8 +39,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node memory critically high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.memoryHigh }}
-        runbook_url: {{ .Values.runbooks.node.memoryHigh }}
+        {{- with (.Values.runbooks.node.memoryHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -60,8 +60,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} CPU usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node CPU saturation ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.cpuSaturation }}
-        runbook_url: {{ .Values.runbooks.node.cpuSaturation }}
+        {{- with (.Values.runbooks.node.cpuSaturation | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -84,8 +84,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node CPU critically saturated ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.cpuSaturation }}
-        runbook_url: {{ .Values.runbooks.node.cpuSaturation }}
+        {{- with (.Values.runbooks.node.cpuSaturation | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -107,8 +107,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem almost full ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.filesystemAlmostFull }}
-        runbook_url: {{ .Values.runbooks.node.filesystemAlmostFull }}
+        {{- with (.Values.runbooks.node.filesystemAlmostFull | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -137,8 +137,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node root filesystem critically full ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.filesystemAlmostFull }}
-        runbook_url: {{ .Values.runbooks.node.filesystemAlmostFull }}
+        {{- with (.Values.runbooks.node.filesystemAlmostFull | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -166,8 +166,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} inode usage is
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem inode saturation ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.inodesSaturation }}
-        runbook_url: {{ .Values.runbooks.node.inodesSaturation }}
+        {{- with (.Values.runbooks.node.inodesSaturation | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -196,8 +196,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node root filesystem inodes critically saturated ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.inodesSaturation }}
-        runbook_url: {{ .Values.runbooks.node.inodesSaturation }}
+        {{- with (.Values.runbooks.node.inodesSaturation | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -225,8 +225,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} root filesystem is predicted to fill up
           within 24 hours on cluster {{ .Values.clusterRegion }}.
         summary: Node root filesystem predicted to be full in 24h ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.filesystemSpaceFillingUp }}
-        runbook_url: {{ .Values.runbooks.node.filesystemSpaceFillingUp }}
+        {{- with (.Values.runbooks.node.filesystemSpaceFillingUp | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -260,8 +260,8 @@ spec:
           Node {{ "{{" }} $labels.node {{ "}}" }} has {{ "{{" }} $labels.condition {{ "}}" }}
           pressure on cluster {{ .Values.clusterRegion }}.
         summary: Node pressure condition active ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.pressure }}
-        runbook_url: {{ .Values.runbooks.node.pressure }}
+        {{- with (.Values.runbooks.node.pressure | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         kube_node_status_condition{
@@ -280,8 +280,8 @@ spec:
           Node {{ "{{" }} $labels.instance {{ "}}" }} normalized load is
           {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
         summary: Node load saturation high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.loadHigh }}
-        runbook_url: {{ .Values.runbooks.node.loadHigh }}
+        {{- with (.Values.runbooks.node.loadHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -306,8 +306,8 @@ spec:
           {{ "{{" }} printf "%.2f" $value {{ "}}" }}x on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Node load critically saturated ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.node.loadHigh }}
-        runbook_url: {{ .Values.runbooks.node.loadHigh }}
+        {{- with (.Values.runbooks.node.loadHigh | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (

--- a/charts/kube-prometheus-rules/templates/pvc-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/pvc-rules.yaml
@@ -17,8 +17,8 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
         summary: PVC is almost full ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.fillingUp }}
-        runbook_url: {{ .Values.runbooks.pvc.fillingUp }}
+        {{- with (.Values.runbooks.pvc.fillingUp | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -38,8 +38,8 @@ spec:
           is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC is critically full ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.fillingUp }}
-        runbook_url: {{ .Values.runbooks.pvc.fillingUp }}
+        {{- with (.Values.runbooks.pvc.fillingUp | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -58,8 +58,8 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           inode usage is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
         summary: PVC inodes almost exhausted ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.inodesFillingUp }}
-        runbook_url: {{ .Values.runbooks.pvc.inodesFillingUp }}
+        {{- with (.Values.runbooks.pvc.inodesFillingUp | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -82,8 +82,8 @@ spec:
           inode usage is {{ "{{" }} printf "%.0f" $value {{ "}}" }}% on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC inodes critically exhausted ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.inodesFillingUp }}
-        runbook_url: {{ .Values.runbooks.pvc.inodesFillingUp }}
+        {{- with (.Values.runbooks.pvc.inodesFillingUp | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -105,8 +105,8 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is predicted to fill up within {{ .Values.rules.pvc.predictFullInHours }} hours on cluster {{ .Values.clusterRegion }}.
         summary: PVC predicted to be full in {{ .Values.rules.pvc.predictFullInHours }}h ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.fillingUpPredicted }}
-        runbook_url: {{ .Values.runbooks.pvc.fillingUpPredicted }}
+        {{- with (.Values.runbooks.pvc.fillingUpPredicted | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -130,8 +130,8 @@ spec:
           PVC {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} is in {{ "{{" }} $labels.phase {{ "}}" }}
           phase on cluster {{ .Values.clusterRegion }}.
         summary: PVC in Failed or Pending state ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.errors }}
-        runbook_url: {{ .Values.runbooks.pvc.errors }}
+        {{- with (.Values.runbooks.pvc.errors | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         kube_persistentvolume_status_phase{
@@ -149,8 +149,8 @@ spec:
           PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }}
           is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
         summary: PVC daily growth rate abnormal ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.growthAbnormal }}
-        runbook_url: {{ .Values.runbooks.pvc.growthAbnormal }}
+        {{- with (.Values.runbooks.pvc.growthAbnormal | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -171,8 +171,8 @@ spec:
           is growing at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% per day on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: PVC daily growth rate critically high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.pvc.growthAbnormal }}
-        runbook_url: {{ .Values.runbooks.pvc.growthAbnormal }}
+        {{- with (.Values.runbooks.pvc.growthAbnormal | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (

--- a/charts/kube-prometheus-rules/templates/target-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/target-rules.yaml
@@ -17,8 +17,8 @@ spec:
           Scrape target {{ "{{" }} $labels.job {{ "}}" }} instance {{ "{{" }} $labels.instance {{ "}}" }}
           is down on cluster {{ .Values.clusterRegion }}.
         summary: Scrape target down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.scrapeTargetDown }}
-        runbook_url: {{ .Values.runbooks.targets.scrapeTargetDown }}
+        {{- with (.Values.runbooks.targets.scrapeTargetDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         up{cluster_region="{{ .Values.clusterRegion }}"} == 0
@@ -34,8 +34,8 @@ spec:
           has been down for 5m on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Scrape target persistently down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.scrapeTargetDown }}
-        runbook_url: {{ .Values.runbooks.targets.scrapeTargetDown }}
+        {{- with (.Values.runbooks.targets.scrapeTargetDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         up{cluster_region="{{ .Values.clusterRegion }}"} == 0
@@ -50,8 +50,8 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}% of scrape targets are down
           on cluster {{ .Values.clusterRegion }}.
         summary: High scrape error ratio ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.scrapeErrorRatio }}
-        runbook_url: {{ .Values.runbooks.targets.scrapeErrorRatio }}
+        {{- with (.Values.runbooks.targets.scrapeErrorRatio | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -71,8 +71,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Critical scrape error ratio ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.scrapeErrorRatio }}
-        runbook_url: {{ .Values.runbooks.targets.scrapeErrorRatio }}
+        {{- with (.Values.runbooks.targets.scrapeErrorRatio | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -91,8 +91,8 @@ spec:
           HAProxy backend {{ "{{" }} $labels.proxy {{ "}}" }} is down
           on cluster {{ .Values.clusterRegion }}.
         summary: HAProxy backend down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.haproxyBackendDown }}
-        runbook_url: {{ .Values.runbooks.targets.haproxyBackendDown }}
+        {{- with (.Values.runbooks.targets.haproxyBackendDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         haproxy_backend_status{
@@ -111,8 +111,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: HAProxy backend persistently down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.haproxyBackendDown }}
-        runbook_url: {{ .Values.runbooks.targets.haproxyBackendDown }}
+        {{- with (.Values.runbooks.targets.haproxyBackendDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         haproxy_backend_status{
@@ -130,8 +130,8 @@ spec:
           MongoDB exporter instance {{ "{{" }} $labels.instance {{ "}}" }} is down
           on cluster {{ .Values.clusterRegion }}.
         summary: MongoDB exporter down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.mongodbExporterDown }}
-        runbook_url: {{ .Values.runbooks.targets.mongodbExporterDown }}
+        {{- with (.Values.runbooks.targets.mongodbExporterDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0
@@ -147,8 +147,8 @@ spec:
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: MongoDB exporter persistently down ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.targets.mongodbExporterDown }}
-        runbook_url: {{ .Values.runbooks.targets.mongodbExporterDown }}
+        {{- with (.Values.runbooks.targets.mongodbExporterDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         mongodb_up{cluster_region="{{ .Values.clusterRegion }}"} == 0

--- a/charts/kube-prometheus-rules/templates/velero-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/velero-rules.yaml
@@ -18,8 +18,8 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}h ago on cluster {{ .Values.clusterRegion }}.
           Backup may have been skipped or failed.
         summary: Velero backup stale ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.velero.backupStale }}
-        runbook_url: {{ .Values.runbooks.velero.backupStale }}
+        {{- with (.Values.runbooks.velero.backupStale | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -40,8 +40,8 @@ spec:
           {{ "{{" }} printf "%.1f" $value {{ "}}" }}h ago on cluster {{ .Values.clusterRegion }}.
           Immediate action required — multiple consecutive backup runs may have failed.
         summary: Velero backup critically stale ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.velero.backupStale }}
-        runbook_url: {{ .Values.runbooks.velero.backupStale }}
+        {{- with (.Values.runbooks.velero.backupStale | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (

--- a/charts/kube-prometheus-rules/templates/workload-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/workload-rules.yaml
@@ -18,8 +18,8 @@ spec:
           container {{ "{{" }} $labels.container {{ "}}" }} restarted
           {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
         summary: Pod restart spike detected ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.podRestartSpike }}
-        runbook_url: {{ .Values.runbooks.workload.podRestartSpike }}
+        {{- with (.Values.runbooks.workload.podRestartSpike | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         increase(kube_pod_container_status_restarts_total{
@@ -38,8 +38,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }} times in the last 15m on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Pod restart spike critical ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.podRestartSpike }}
-        runbook_url: {{ .Values.runbooks.workload.podRestartSpike }}
+        {{- with (.Values.runbooks.workload.podRestartSpike | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         increase(kube_pod_container_status_restarts_total{
@@ -56,8 +56,8 @@ spec:
           {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of pods in namespace
           {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
         summary: High pod not-ready ratio ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.podNotReady }}
-        runbook_url: {{ .Values.runbooks.workload.podNotReady }}
+        {{- with (.Values.runbooks.workload.podNotReady | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -86,8 +86,8 @@ spec:
           {{ "{{" }} $labels.namespace {{ "}}" }} are not ready on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Critical pod not-ready ratio ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.podNotReady }}
-        runbook_url: {{ .Values.runbooks.workload.podNotReady }}
+        {{- with (.Values.runbooks.workload.podNotReady | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -115,8 +115,8 @@ spec:
           Deployment {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.deployment {{ "}}" }}
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
         summary: Workload unavailable replica ratio high ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.workloadUnavailable }}
-        runbook_url: {{ .Values.runbooks.workload.workloadUnavailable }}
+        {{- with (.Values.runbooks.workload.workloadUnavailable | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -140,8 +140,8 @@ spec:
           has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% replicas unavailable on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: Workload unavailable replica ratio critical ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.workloadUnavailable }}
-        runbook_url: {{ .Values.runbooks.workload.workloadUnavailable }}
+        {{- with (.Values.runbooks.workload.workloadUnavailable | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -164,8 +164,8 @@ spec:
           HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
           is at {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of max replicas on cluster {{ .Values.clusterRegion }}.
         summary: HPA near maximum replicas ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.hpaMaxedReplicas }}
-        runbook_url: {{ .Values.runbooks.workload.hpaMaxedReplicas }}
+        {{- with (.Values.runbooks.workload.hpaMaxedReplicas | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -189,8 +189,8 @@ spec:
           has reached maximum replicas on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: HPA at maximum replicas ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.hpaMaxedReplicas }}
-        runbook_url: {{ .Values.runbooks.workload.hpaMaxedReplicas }}
+        {{- with (.Values.runbooks.workload.hpaMaxedReplicas | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         (
@@ -213,8 +213,8 @@ spec:
           HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
           scaling is limited or failing on cluster {{ .Values.clusterRegion }}.
         summary: HPA scaling limited or failing ({{ .Values.clusterRegion }})
-        {{- if .Values.runbooks.workload.hpaScalingLimited }}
-        runbook_url: {{ .Values.runbooks.workload.hpaScalingLimited }}
+        {{- with (.Values.runbooks.workload.hpaScalingLimited | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
         {{- end }}
       expr: |-
         kube_horizontalpodautoscaler_status_condition{

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -91,6 +91,9 @@ rules:
 # Runbook URLs for each alert — set to your internal Notion/Confluence pages in the version stream.
 # Leave empty ("") to omit the runbook_url annotation from the PrometheusRule.
 runbooks:
+  # Fallback URL used when a specific alert's runbook URL is not set.
+  # Set this in the version stream to your general alerts runbook page.
+  default: ""
   node:
     memoryHigh: ""
     cpuSaturation: ""


### PR DESCRIPTION
## Summary

- Add `runbooks.default` key to `values.yaml` — a fallback URL used when a specific alert's runbook URL is not configured
- All 47 `runbook_url` annotations across 6 templates now use `| default .Values.runbooks.default` — specific URL wins, falls back to default, omitted if both empty
- Set `runbooks.default` in the version stream to a general Notion page to provide a triage entry point for all alerts

## Version Stream Candidates

`runbooks.default` placeholder already added to sbg5 and bhs5 version stream values. Fill in the Notion URL when the page is ready:
```yaml
runbooks:
  default: "https://www.notion.so/your-general-alerts-page"
```

## Helm Chart Suggestions

None.

## Test Plan

- [ ] Merge and verify chart publishes at `0.7.1`
- [ ] Set `runbooks.default` to a test URL in sbg5 version stream — confirm all alerts render with the URL
- [ ] Set a specific alert URL — confirm it overrides the default