### PR TITLE
fix(kube-prometheus-rules): correct expressions and tighten noisy alerts — v0.8.0

### DIFF
--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "1.0.0"
 maintainers:
   - name: lop3z

--- a/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/kube-api-rules.yaml
@@ -140,20 +140,22 @@ spec:
         severity: critical
         cluster_region: {{ .Values.clusterRegion }}
 
+    # Lateness = time() - next_schedule_time. Negative when on schedule (next run still in future),
+    # positive when overdue. Period-agnostic — works for hourly, daily, monthly cronjobs.
     - alert: KubeCronJobMissedSchedule
       annotations:
         description: >
           CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.cronjob {{ "}}" }}
-          has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
+          is {{ "{{" }} printf "%.0f" $value {{ "}}" }}s past its scheduled run time
           on cluster {{ .Values.clusterRegion }}.
         summary: CronJob missed schedule ({{ .Values.clusterRegion }})
         {{- with (.Values.runbooks.kubeApi.cronJobMissedSchedule | default .Values.runbooks.default) }}
         runbook_url: {{ . }}
         {{- end }}
       expr: |-
-        time() - kube_cronjob_status_last_schedule_time{
+        time() - kube_cronjob_next_schedule_time{
           cluster_region="{{ .Values.clusterRegion }}"
-        } > {{ .Values.rules.kubeApi.cronJobMissedWarningSeconds }}
+        } > {{ .Values.rules.kubeApi.cronJobLateWarningSeconds }}
       for: 0m
       labels:
         severity: warning
@@ -163,7 +165,7 @@ spec:
       annotations:
         description: >
           CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.cronjob {{ "}}" }}
-          has not been scheduled for {{ "{{" }} printf "%.0f" $value {{ "}}" }}s
+          is {{ "{{" }} printf "%.0f" $value {{ "}}" }}s past its scheduled run time
           on cluster {{ .Values.clusterRegion }}.
           Immediate action required.
         summary: CronJob missed schedule critically overdue ({{ .Values.clusterRegion }})
@@ -171,9 +173,9 @@ spec:
         runbook_url: {{ . }}
         {{- end }}
       expr: |-
-        time() - kube_cronjob_status_last_schedule_time{
+        time() - kube_cronjob_next_schedule_time{
           cluster_region="{{ .Values.clusterRegion }}"
-        } > {{ .Values.rules.kubeApi.cronJobMissedCriticalSeconds }}
+        } > {{ .Values.rules.kubeApi.cronJobLateCriticalSeconds }}
       for: 0m
       labels:
         severity: critical

--- a/charts/kube-prometheus-rules/templates/node-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/node-rules.yaml
@@ -286,7 +286,7 @@ spec:
       expr: |-
         (
           node_load5{cluster_region="{{ .Values.clusterRegion }}"}
-          /
+          / on(instance, cluster_region)
           count by (instance, cluster_region) (
             node_cpu_seconds_total{
               mode="idle",
@@ -312,7 +312,7 @@ spec:
       expr: |-
         (
           node_load5{cluster_region="{{ .Values.clusterRegion }}"}
-          /
+          / on(instance, cluster_region)
           count by (instance, cluster_region) (
             node_cpu_seconds_total{
               mode="idle",

--- a/charts/kube-prometheus-rules/templates/workload-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/workload-rules.yaml
@@ -59,19 +59,18 @@ spec:
         {{- with (.Values.runbooks.workload.podNotReady | default .Values.runbooks.default) }}
         runbook_url: {{ . }}
         {{- end }}
+      # Only count pods in Running phase that aren't Ready — excludes Succeeded/Failed
+      # pods (e.g. completed Job pods in jx-git-operator that linger as Ready=false).
       expr: |-
         (
           count by (namespace, cluster_region) (
-            kube_pod_status_ready{
-              condition="false",
-              cluster_region="{{ .Values.clusterRegion }}"
-            } == 1
+            (kube_pod_status_phase{phase="Running",cluster_region="{{ .Values.clusterRegion }}"} == 1)
+            unless on (namespace, pod, cluster_region)
+            (kube_pod_status_ready{condition="true",cluster_region="{{ .Values.clusterRegion }}"} == 1)
           )
           /
           count by (namespace, cluster_region) (
-            kube_pod_status_ready{
-              cluster_region="{{ .Values.clusterRegion }}"
-            }
+            kube_pod_status_phase{phase="Running",cluster_region="{{ .Values.clusterRegion }}"} == 1
           )
         ) * 100 > {{ .Values.rules.workload.podNotReadyWarningThreshold }}
       for: 10m
@@ -92,16 +91,13 @@ spec:
       expr: |-
         (
           count by (namespace, cluster_region) (
-            kube_pod_status_ready{
-              condition="false",
-              cluster_region="{{ .Values.clusterRegion }}"
-            } == 1
+            (kube_pod_status_phase{phase="Running",cluster_region="{{ .Values.clusterRegion }}"} == 1)
+            unless on (namespace, pod, cluster_region)
+            (kube_pod_status_ready{condition="true",cluster_region="{{ .Values.clusterRegion }}"} == 1)
           )
           /
           count by (namespace, cluster_region) (
-            kube_pod_status_ready{
-              cluster_region="{{ .Values.clusterRegion }}"
-            }
+            kube_pod_status_phase{phase="Running",cluster_region="{{ .Values.clusterRegion }}"} == 1
           )
         ) * 100 > {{ .Values.rules.workload.podNotReadyCriticalThreshold }}
       for: 10m
@@ -207,23 +203,4 @@ spec:
         severity: critical
         cluster_region: {{ .Values.clusterRegion }}
 
-    - alert: KubeHPAScalingLimited
-      annotations:
-        description: >
-          HPA {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.horizontalpodautoscaler {{ "}}" }}
-          scaling is limited or failing on cluster {{ .Values.clusterRegion }}.
-        summary: HPA scaling limited or failing ({{ .Values.clusterRegion }})
-        {{- with (.Values.runbooks.workload.hpaScalingLimited | default .Values.runbooks.default) }}
-        runbook_url: {{ . }}
-        {{- end }}
-      expr: |-
-        kube_horizontalpodautoscaler_status_condition{
-          condition="ScalingLimited",
-          status="true",
-          cluster_region="{{ .Values.clusterRegion }}"
-        } == 1
-      for: 5m
-      labels:
-        severity: warning
-        cluster_region: {{ .Values.clusterRegion }}
 {{- end }}

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -71,9 +71,11 @@ rules:
     # Job failure thresholds (count in 30m)
     jobFailedWarning: 1
     jobFailedCritical: 3
-    # CronJob missed schedule thresholds (seconds since last schedule)
-    cronJobMissedWarningSeconds: 1800
-    cronJobMissedCriticalSeconds: 3600
+    # CronJob lateness thresholds (seconds past kube_cronjob_next_schedule_time —
+    # period-agnostic: works for hourly, daily, weekly cronjobs alike).
+    # Default: warn after 10m late, page after 30m late.
+    cronJobLateWarningSeconds: 600
+    cronJobLateCriticalSeconds: 1800
 
   targets:
     enabled: true
@@ -113,7 +115,6 @@ runbooks:
     podNotReady: ""
     workloadUnavailable: ""
     hpaMaxedReplicas: ""
-    hpaScalingLimited: ""
   targets:
     scrapeTargetDown: ""
     scrapeErrorRatio: ""


### PR DESCRIPTION
## Summary

Found these issues while reviewing thresholds against live prod Mimir for DEV-199. All four were either dead-on-arrival or permanent noise.

| # | Rule | Issue | Fix |
|---|---|---|---|
| 1 | `KubeNodeLoadHigh` (N11/N12) | Expression had a vector-match bug — `node_load5 / count by (instance, cluster_region)(...)` never matched (LHS keeps extra labels, default 1:1 matching needs identical label sets). Rule was effectively dead. | Add `on(instance, cluster_region)` to the division. |
| 2 | `KubePodNotReadyRatioHigh` (W3/W4) | Fired 16–25% in all 4 clusters because completed Job pods in `jx-git-operator` stay around with `Ready=false`. | Only count pods in `phase="Running"` that aren't Ready (excludes Succeeded/Failed). |
| 3 | `KubeCronJobMissedSchedule` (A7/A8) | `time() - last_schedule_time > 1800s` always fires for daily cronjobs (period >> threshold). Permanent false positive for `lopez-backend-cron` and `lopez-node-peer-dau` on sbg5. | Use `time() - kube_cronjob_next_schedule_time > N` — period-agnostic, works for any frequency. New defaults: 600s warn / 1800s crit (lateness past scheduled run time). |
| 4 | `KubeHPAScalingLimited` (W9) | `ScalingLimited=true` is the steady state when an HPA is at min or max — fired across all 4 clusters (16 HPAs) without signaling a real problem. | Remove. `KubeHPAMaxedReplicas` already covers the "stuck at max" case. |

### Verification against current prod data

| Rule | Before | After |
|---|---|---|
| N11/N12 (load) | dead — never fired | sgp1: 1 real node at 2.40× (correct signal) |
| W3 (not-ready) | fired in all 4 clusters | 0 firing |
| A7/A8 (cronjob) | fired in sbg5 (daily jobs) | 0 firing |
| W9 (HPAScalingLimited) | 16 HPAs across all clusters | removed |

### Breaking values changes

`rules.kubeApi.cronJobMissedWarningSeconds` → `rules.kubeApi.cronJobLateWarningSeconds` (default 1800 → **600**)
`rules.kubeApi.cronJobMissedCriticalSeconds` → `rules.kubeApi.cronJobLateCriticalSeconds` (default 3600 → **1800**)
`runbooks.workload.hpaScalingLimited` removed.

The semantics of the threshold also changed (lateness vs. time-since-last-schedule), so any per-cluster overrides will need to be re-tuned.

## Version Stream Candidates

None — the override file `jx3-versions/charts/lop3z/kube-prometheus-rules/values.yaml.gotmpl` only sets `clusterRegion` and `runbooks.default`, so no follow-up edits needed there.

## Helm Chart Suggestions

None.

## Test Plan

- [ ] `helm template test charts/kube-prometheus-rules --set clusterRegion=sbg5` renders cleanly (verified locally)
- [ ] After publish: bump version in `jx3-versions/charts/lop3z/kube-prometheus-rules/defaults.yaml` to 0.8.0
- [ ] Verify in dev-sbg5 (already running this chart) that no false-positive alerts fire post-upgrade
- [ ] Roll out to prod via DEV-195 subtask (rules instantiation)

ref DEV-199