### PR TITLE
feat(kube-prometheus-rules): add WireGuard alerts

### DIFF
--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.10.0
+version: 0.12.0
 appVersion: "1.0.0"
 maintainers:
   - name: lop3z

--- a/charts/kube-prometheus-rules/templates/wireguard-rules.yaml
+++ b/charts/kube-prometheus-rules/templates/wireguard-rules.yaml
@@ -1,0 +1,136 @@
+{{- if .Values.rules.wireguard.enabled }}
+{{- $sevWarn := ternary "wip_warning" "warning" .Values.rules.wireguard.warningSuppressed }}
+{{- $sevCrit := ternary "wip_critical" "critical" .Values.rules.wireguard.criticalSuppressed }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-wireguard
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-prometheus-rules.labels" . | nindent 4 }}
+    gitops.jenkins-x.io/pipeline: namespaces
+spec:
+  groups:
+  - name: wireguard
+    rules:
+    # ── Tunnel handshake age — the primary "tunnel down" signal ─────────────
+    - alert: WireGuardTunnelHandshakeStale
+      annotations:
+        description: >
+          WireGuard tunnel on {{ "{{" }} $labels.instance {{ "}}" }} hasn't completed a handshake
+          in {{ "{{" }} printf "%.0fs" $value {{ "}}" }} (threshold: {{ .Values.rules.wireguard.handshakeStaleSeconds }}s).
+          cluster_region={{ "{{" }} $labels.cluster_region {{ "}}" }}
+        summary: WireGuard handshake stale ({{ "{{" }} $labels.instance {{ "}}" }})
+        {{- with (.Values.runbooks.wireguard.handshakeStale | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        time() - wireguard_latest_handshake_seconds > {{ .Values.rules.wireguard.handshakeStaleSeconds }}
+      for: 2m
+      labels:
+        severity: {{ $sevWarn }}
+
+    - alert: WireGuardTunnelHandshakeStale
+      annotations:
+        description: >
+          WireGuard tunnel on {{ "{{" }} $labels.instance {{ "}}" }} hasn't completed a handshake
+          for over 5 minutes. Immediate action required.
+        summary: WireGuard handshake persistently stale ({{ "{{" }} $labels.instance {{ "}}" }})
+        {{- with (.Values.runbooks.wireguard.handshakeStale | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        time() - wireguard_latest_handshake_seconds > {{ .Values.rules.wireguard.handshakeStaleSeconds }}
+      for: 5m
+      labels:
+        severity: {{ $sevCrit }}
+
+    # ── Gateway VM unreachable — node_exporter or VM itself down ────────────
+    - alert: WireGuardGatewayDown
+      annotations:
+        description: >
+          WireGuard gateway VM {{ "{{" }} $labels.instance {{ "}}" }} is not responding to scrape.
+          cluster_region={{ "{{" }} $labels.cluster_region {{ "}}" }}
+        summary: WireGuard gateway down ({{ "{{" }} $labels.instance {{ "}}" }})
+        {{- with (.Values.runbooks.wireguard.gatewayDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        up{job="wireguard"} == 0
+      for: 2m
+      labels:
+        severity: {{ $sevWarn }}
+
+    - alert: WireGuardGatewayDown
+      annotations:
+        description: >
+          WireGuard gateway VM {{ "{{" }} $labels.instance {{ "}}" }} has been unreachable for 5m.
+          cluster_region={{ "{{" }} $labels.cluster_region {{ "}}" }}
+        summary: WireGuard gateway persistently down ({{ "{{" }} $labels.instance {{ "}}" }})
+        {{- with (.Values.runbooks.wireguard.gatewayDown | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        up{job="wireguard"} == 0
+      for: 5m
+      labels:
+        severity: {{ $sevCrit }}
+
+    # ── Dead-man's-switch: a whole region stopped reporting ─────────────────
+    # `absent_over_time` fires when expected `up{job="wireguard"}` series for a given
+    # cluster_region have been missing for the full window. Catches the case where
+    # the local Alloy is dead or the cluster can't remote_write to Mimir — i.e.
+    # nothing else can detect because there's no data to evaluate against.
+    {{- range $region := .Values.rules.wireguard.deadManRegions }}
+    - alert: WireGuardMetricsAbsent
+      annotations:
+        description: >
+          No WireGuard metrics from cluster_region={{ $region }} for over
+          {{ $.Values.rules.wireguard.deadManAbsentMinutes }}m. Either the local Alloy
+          is down, the cluster can't remote_write, or all WG VMs in that region are gone.
+        summary: WireGuard metrics absent ({{ $region }})
+        {{- with ($.Values.runbooks.wireguard.metricsAbsent | default $.Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        absent_over_time(up{job="wireguard",cluster_region="{{ $region }}"}[{{ $.Values.rules.wireguard.deadManAbsentMinutes }}m]) == 1
+      for: 0m
+      labels:
+        severity: {{ $sevWarn }}
+        cluster_region: {{ $region }}
+    {{- end }}
+
+    # ── Keepalived master state changed (info — failover event) ─────────────
+    # Fires on every VRRP transition. Severity: info — failover is a normal
+    # operational event (drills, brief peer flaps, etc.) — informational, not pageworthy.
+    - alert: KeepalivedMasterChanged
+      annotations:
+        description: >
+          keepalived_is_master changed on {{ "{{" }} $labels.instance {{ "}}" }} for VIP {{ "{{" }} $labels.vip {{ "}}" }}
+          in the last 5 minutes. Could be a normal failover, a drill, or unexpected flapping.
+        summary: Keepalived state change on {{ "{{" }} $labels.instance {{ "}}" }} (VIP {{ "{{" }} $labels.vip {{ "}}" }})
+        {{- with (.Values.runbooks.wireguard.masterChanged | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        changes(keepalived_is_master[5m]) > 0
+      for: 0m
+      labels:
+        severity: info
+
+    # ── Keepalived flapping (warning — sustained failover loop) ─────────────
+    - alert: KeepalivedFlapping
+      annotations:
+        description: >
+          keepalived_is_master changed {{ "{{" }} $value {{ "}}" }} times on {{ "{{" }} $labels.instance {{ "}}" }}
+          (VIP {{ "{{" }} $labels.vip {{ "}}" }}) in the last 15 minutes — likely a track script bouncing right at threshold.
+        summary: Keepalived flapping on {{ "{{" }} $labels.instance {{ "}}" }}
+        {{- with (.Values.runbooks.wireguard.flapping | default .Values.runbooks.default) }}
+        runbook_url: {{ . }}
+        {{- end }}
+      expr: |-
+        changes(keepalived_is_master[15m]) >= {{ .Values.rules.wireguard.flapThreshold }}
+      for: 0m
+      labels:
+        severity: {{ $sevWarn }}
+{{- end }}

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -119,6 +119,25 @@ rules:
     # Hours since last successful backup before critical (default: 49h — missed 2 consecutive runs)
     staleCriticalHours: 49
 
+  wireguard:
+    enabled: true
+    warningSuppressed: true
+    criticalSuppressed: true
+    # Handshake age threshold — seconds since last successful WG handshake before
+    # we treat the tunnel as stale. Warning at 2m breach, critical at 5m.
+    handshakeStaleSeconds: 180
+    # Dead-man's-switch — if no `up{job="wireguard"}` series for a cluster_region in this
+    # window, fire. Evaluated on the central Mimir ruler so it works even when the
+    # affected cluster can't remote_write at all.
+    deadManAbsentMinutes: 10
+    # Cluster regions to evaluate the dead-man's-switch against — one alert per region.
+    # Add a new region here when a new cluster starts scraping WG VMs.
+    deadManRegions:
+      - bhs5
+      - us-va1
+    # Keepalived flap detection — warn when this many master-state changes happen in 15m.
+    flapThreshold: 3
+
 # Runbook URLs for each alert — set to your internal Notion/Confluence pages in the version stream.
 # Leave empty ("") to omit the runbook_url annotation from the PrometheusRule.
 runbooks:
@@ -156,3 +175,9 @@ runbooks:
     cronJobMissedSchedule: ""
   velero:
     backupStale: ""
+  wireguard:
+    handshakeStale: ""
+    gatewayDown: ""
+    metricsAbsent: ""
+    masterChanged: ""
+    flapping: ""


### PR DESCRIPTION
## Summary
Adds a new `wireguard` rule group with 5 alerts (8 instances total). All ship default-suppressed (`wip_warning`/`wip_critical`/`info`) so they soak silently before being flipped to live notifications.

| Alert | Severity | Window | Purpose |
|---|---|---|---|
| `WireGuardTunnelHandshakeStale` | warn 2m / crit 5m | `time() - wireguard_latest_handshake_seconds > 180` | Primary tunnel-down signal |
| `WireGuardGatewayDown` | warn 2m / crit 5m | `up{job="wireguard"} == 0` | Gateway VM unreachable |
| `WireGuardMetricsAbsent` | warn 0m | `absent_over_time(up{...}[10m]) == 1` per region | Dead-man's-switch (catches "cluster can't even report") |
| `KeepalivedMasterChanged` | info 0m | `changes(keepalived_is_master[5m]) > 0` | Failover observed (drill, planned, or unexpected) |
| `KeepalivedFlapping` | warn 0m | `changes(keepalived_is_master[15m]) >= 3` | Failover loop — track script bouncing |

Chart version `0.10.0 → 0.12.0` (skipping `0.11.0` reserved for #10 / DEV-300).

ref DEV-269

## Version Stream Candidates
Pin the new `0.12.0` in `jx3-versions/charts/lop3z/kube-prometheus-rules/defaults.yaml` (separate PR after publish).

## Helm Chart Suggestions
None — this IS the helm chart change.