### PR TITLE
feat(netbird-access): publish chart (promoted from kube-dev cluster-local)

### DIFF
--- a/charts/netbird-access/Chart.yaml
+++ b/charts/netbird-access/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: netbird-access
+description: NetBird CRs exposing in-cluster Mongo & ClickHouse over WireGuard, access via JWT-issued per-DB groups (DEV-123)
+type: application
+version: 0.2.0
+appVersion: 0.6.0

--- a/charts/netbird-access/README.md
+++ b/charts/netbird-access/README.md
@@ -1,0 +1,117 @@
+# netbird-access
+
+Exposes databases to NetBird peers via the NetBird Kubernetes operator, with **per-database**
+least-privilege groups (`netbird-clickhouse`, `netbird-mongo`). Part of DEV-123.
+
+## What this chart manages (GitOps)
+- `NetworkRouter` (`router.name`) — operator deploys the routing-peer pods, registered under `dnsZone`.
+- `NetworkResource` ×2 — **no group on the resource**; access is granted by a per-resource policy:
+  - **clickhouse** → `clickhouseService` ClusterIP (for when the app's own Service is NodePort/headless)
+  - **mongos** → `mongoService` selector-less ClusterIP → external mongos (`mongoService.externalHost`, for when MongoDB is off-cluster)
+- The two optional Services above (`clickhouseService.create` / `mongoService.create`).
+
+**All cluster-specific values** (`dnsZone`, `router.name`, `mongoService.externalHost`, selectors) are
+supplied **per cluster via versionStream** — see `values.yaml` for the keys. Examples below use the
+SBG5-dev values (`jx-staging-router`, `sbg5.dev.netbird.lop3z.one`, external mongos `51.68.95.180`).
+
+**This chart does NOT create the access Groups or any SetupKeys** — see the access model below for why.
+
+## Access model (SSO-driven, per database)
+A user's Keycloak realm roles ride in the `groups` claim (netbird client's realm-role→groups mapper).
+NetBird **JWT group-sync** creates a NetBird group for each claim value and auto-adds the peer on login.
+
+> ### ⚠️ Groups must be JWT-issued, NOT operator-created
+> NetBird only adds peers to groups it **issued itself (`issued=jwt`)**. A group created by the
+> operator (or the API) is `issued=api`, and **JWT sync silently refuses to populate it** — peers
+> never join and SSO access fails with no error. So the access groups `netbird-clickhouse` /
+> `netbird-mongo` must be **created by JWT sync** (from the same-named realm roles), which means the
+> operator must NOT create same-named groups. That's why this chart no longer ships a `Group` (or
+> `SetupKey`, whose `autoGroups` would need an operator group). The resources carry **no group** and
+> access is granted purely by policy `destinationResource`.
+
+**Grant a user access** = add them to the lopz-rbac group (one-line PR), then they `netbird up`:
+- ClickHouse → `/anyip-staging/netbird/clickhouse` (role `netbird-clickhouse`)
+- MongoDB → `/anyip-staging/netbird/mongo` (role `netbird-mongo`)
+Removing the role revokes on next login (full-sync).
+
+## ⚠️ Manual steps the operator CANNOT do (out-of-band, one-time per env)
+
+### 1. Enable JWT group-sync (account setting)
+```bash
+export NB_TOKEN=$(kubectl -n netbird get secret netbird-mgmt-api-key -o jsonpath='{.data.NB_API_KEY}' | base64 -d)
+API=https://vpn.lop3z.one/api
+ACC=$(curl -s -H "Authorization: Token $NB_TOKEN" "$API/accounts" | jq -r '.[0].id')
+curl -s -X PUT -H "Authorization: Token $NB_TOKEN" -H "Content-Type: application/json" \
+  -d '{"settings":{"jwt_groups_enabled":true,"jwt_groups_claim_name":"groups",
+       "jwt_allow_groups":[],"groups_propagation_enabled":true}}' \
+  "$API/accounts/$ACC"
+```
+> **`jwt_allow_groups` MUST be empty `[]`.** It is a **login gate**, not a propagation filter — set
+> it to anything and every user whose token lacks those groups gets **401 on the portal** (this was
+> the original "other users get 401" bug). Least-privilege is enforced by the **policies** below,
+> not by this setting. With it empty, NetBird mirrors every realm role as a group (cosmetic clutter).
+
+### 2. Per-resource access policies (REQUIRED — nothing is reachable without them)
+The operator can't create access policies. Use **one policy per resource** — NetBird does **not**
+reliably distribute two `destinationResource` rules in a single policy (only the first resource gets
+routed; symptom: one DB works, the other times out). The policy **source is the jwt-issued group**,
+which only exists **after** the first user with that role logs in.
+```bash
+# group ids (jwt-issued, appear after first SSO login): .../groups
+# resource ids: .../networks/<network-id>/resources
+CH_GRP=...; CH_RES=...; MONGO_GRP=...; MONGO_RES=...
+curl -s -X POST -H "Authorization: Token $NB_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"name\":\"netbird-db-access\",\"enabled\":true,\"rules\":[
+        {\"name\":\"clickhouse\",\"enabled\":true,\"action\":\"accept\",\"bidirectional\":true,\"protocol\":\"all\",
+         \"sources\":[\"$CH_GRP\"],\"destinationResource\":{\"id\":\"$CH_RES\",\"type\":\"host\"}}]}" "$API/policies"
+curl -s -X POST -H "Authorization: Token $NB_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"name\":\"netbird-mongo-access\",\"enabled\":true,\"rules\":[
+        {\"name\":\"mongos\",\"enabled\":true,\"action\":\"accept\",\"bidirectional\":true,\"protocol\":\"all\",
+         \"sources\":[\"$MONGO_GRP\"],\"destinationResource\":{\"id\":\"$MONGO_RES\",\"type\":\"host\"}}]}" "$API/policies"
+```
+
+### 3. DNS zone
+`NetworkRouter.dnsZoneRef` (`sbg5.dev.netbird.lop3z.one`) must exist in NetBird DNS Zones first
+(operator looks it up by name, never creates it).
+
+### 4. Do NOT add client peers to the `networkrouter-*` group
+A peer in the routing-peer group is treated as a **router** and gets **no client route** (symptom:
+`netbird networks list` empty, traffic leaves via the default interface).
+
+### 5. (Optional) DNS names instead of IPs — name-based, VPN-only access
+To let peers reach DBs by **name** (resolvable only on the VPN, not public), add **domain** network
+resources — the operator can't (`NetworkResource` is IP-only), so create them via API. The in-cluster
+router resolves the FQDN via CoreDNS, so there's no kube-dns/subnet exposure. One domain resource +
+one policy per DB (same one-policy-per-resource rule as step 2):
+```bash
+NETID=$(curl -s -H "Authorization: Token $NB_TOKEN" "$API/networks" | jq -r '.[0].id')
+curl -s -X POST -H "Authorization: Token $NB_TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"clickhouse-dns","address":"clickhouse-netbird.<ns>.svc.cluster.local","enabled":true}' \
+  "$API/networks/$NETID/resources"   # repeat for mongo-netbird.<ns>.svc.cluster.local
+# then POST a policy per resource: source = the jwt group, destinationResource = {id, type:"domain"}
+```
+Then connect by name: `mongosh "mongodb://mongo-netbird.<ns>.svc.cluster.local:27017/?directConnection=true"`.
+**Do NOT use `external-dns` for this** — that publishes a *public* DNS record; NetBird split-DNS keeps
+the name VPN-only.
+
+> Current live policy set (SBG5 dev): `netbird-clickhouse-access` + `netbird-mongo-access` (IP, step 2)
+> and `netbird-clickhouse-dns` + `netbird-mongo-dns` (domain, step 5).
+>
+> Future improvement: manage the policies + account setting via the NetBird Terraform provider or an
+> idempotent Job, to remove these manual steps.
+
+## Bootstrap order (fresh env)
+1. Merge this chart → operator creates the router + resources (no groups).
+2. Enable JWT group-sync (step 1) with `jwt_allow_groups: []`.
+3. Assign the `netbird-clickhouse` / `netbird-mongo` roles to a user in lopz-rbac; have them
+   `netbird up` once → JWT sync creates the jwt groups and joins their peer.
+4. Read the jwt group ids + resource ids, create the two policies (step 2).
+
+## Connect
+```bash
+# ClickHouse (peer in netbird-clickhouse)
+curl "http://<clickhouse-route>:8123/?user=default&password=..." --data-binary "SELECT version()"
+# MongoDB mongos (peer in netbird-mongo)
+mongosh "mongodb://<mongos-route>:27017/" --username <user> --authenticationDatabase admin
+```
+Routes/addresses: `netbird networks list` (or NetBird portal → Networks).

--- a/charts/netbird-access/templates/clickhouse-clusterip-svc.yaml
+++ b/charts/netbird-access/templates/clickhouse-clusterip-svc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.clickhouseService.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.clickhouseService.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: netbird-access
+spec:
+  type: ClusterIP
+  selector:
+    {{- toYaml .Values.clickhouseService.selector | nindent 4 }}
+  ports:
+    {{- toYaml .Values.clickhouseService.ports | nindent 4 }}
+{{- end }}

--- a/charts/netbird-access/templates/mongo-external-svc.yaml
+++ b/charts/netbird-access/templates/mongo-external-svc.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.mongoService.create }}
+# Selector-less Service + manual Endpoints pointing at the external mongos. The operator's
+# NetworkResource can only reference a (ClusterIP) Service, so this wraps the off-cluster mongos.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.mongoService.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: netbird-access
+spec:
+  type: ClusterIP
+  ports:
+  - name: mongo
+    port: {{ .Values.mongoService.port }}
+    targetPort: {{ .Values.mongoService.port }}
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ .Values.mongoService.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: netbird-access
+subsets:
+- addresses:
+  - ip: {{ .Values.mongoService.externalHost }}
+  ports:
+  - name: mongo
+    port: {{ .Values.mongoService.port }}
+    protocol: TCP
+{{- end }}

--- a/charts/netbird-access/templates/networkresource-clickhouse.yaml
+++ b/charts/netbird-access/templates/networkresource-clickhouse.yaml
@@ -1,0 +1,17 @@
+# One NetworkResource exposes the whole clickhouse Service (native 9000 + http 8123);
+# the CRD's serviceRef has no per-port field.
+apiVersion: netbird.io/v1alpha1
+kind: NetworkResource
+metadata:
+  name: clickhouse
+  namespace: {{ .Release.Namespace }}
+spec:
+  networkRouterRef:
+    name: {{ .Values.router.name }}
+    namespace: {{ .Release.Namespace }}
+  serviceRef:
+    name: {{ .Values.services.clickhouse }}
+  # No groups: the access group (netbird-clickhouse) is JWT-issued by NetBird from the Keycloak
+  # realm role, so the operator must NOT own that name (an operator/api group can't be populated by
+  # JWT sync). Access is granted by a per-resource policy (destinationResource by ID, source = the
+  # jwt group) — see README "Manual steps".

--- a/charts/netbird-access/templates/networkresource-mongos.yaml
+++ b/charts/netbird-access/templates/networkresource-mongos.yaml
@@ -1,0 +1,15 @@
+apiVersion: netbird.io/v1alpha1
+kind: NetworkResource
+metadata:
+  name: mongos
+  namespace: {{ .Release.Namespace }}
+spec:
+  networkRouterRef:
+    name: {{ .Values.router.name }}
+    namespace: {{ .Release.Namespace }}
+  serviceRef:
+    name: {{ .Values.services.mongos }}
+  # No groups: the access group (netbird-mongo) is JWT-issued by NetBird from the Keycloak realm
+  # role, so the operator must NOT own that name (an operator/api group can't be populated by JWT
+  # sync). Access is granted by a per-resource policy (destinationResource by ID, source = the jwt
+  # group) — see README "Manual steps".

--- a/charts/netbird-access/templates/networkrouter.yaml
+++ b/charts/netbird-access/templates/networkrouter.yaml
@@ -1,0 +1,9 @@
+apiVersion: netbird.io/v1alpha1
+kind: NetworkRouter
+metadata:
+  name: {{ .Values.router.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsZoneRef:
+    name: {{ .Values.dnsZone }}
+  logLevel: {{ .Values.router.logLevel }}

--- a/charts/netbird-access/values.yaml
+++ b/charts/netbird-access/values.yaml
@@ -1,0 +1,37 @@
+# Access model: the access groups (e.g. netbird-clickhouse / netbird-mongo) are JWT-issued by NetBird
+# from same-named Keycloak realm roles — this chart does NOT create them, and the operator must NOT
+# (an api-issued group can't be populated by JWT sync). Access is granted by per-resource NetBird
+# policies (manual — see README "Manual steps"). This chart manages only the routing peer + the
+# in-cluster Services + the NetworkResources. All cluster-specific values below are meant to be
+# supplied per cluster via versionStream; the defaults are conservative placeholders.
+
+# REQUIRED per cluster: the NetBird DNS zone the router registers resources under (must already
+# exist in the NetBird management — the operator looks it up by name, never creates it).
+dnsZone: ""
+
+# Routing peer that joins the NetBird network and routes into ClusterIP space (one per namespace).
+router:
+  name: db-access-router
+  logLevel: info
+
+# In-cluster Services to expose. serviceRef is same-namespace; a NetworkResource exposes the whole
+# Service (all ports).
+services:
+  mongos: mongo-netbird
+  clickhouse: clickhouse-netbird
+
+# Wrap an OUT-OF-CLUSTER endpoint (e.g. external mongos) in a selector-less ClusterIP + Endpoints,
+# since the operator can only reference a ClusterIP Service. Set create:false when the target
+# Service already has its own endpoints.
+mongoService:
+  create: false
+  name: mongo-netbird
+  externalHost: ""        # REQUIRED when create:true — the off-cluster host IP
+  port: 27017
+
+# Add a plain ClusterIP for an in-cluster service whose own Service is NodePort/headless.
+clickhouseService:
+  create: false
+  name: clickhouse-netbird
+  selector: {}
+  ports: []


### PR DESCRIPTION
Promotes the `netbird-access` chart out of `kube-dev-ovh-sbg5/charts/` into the published helm-charts repo, so it can be referenced as `lop3z/netbird-access` (versions pinned in jx3-versions, values per-cluster in versionStream) — same pattern as `kube-oidc-rbac`/`vault-instance`, and ready for prod rollout.

- Templates unchanged (already parameterized); `helm template` with the SBG5 values renders **byte-identical** to the cluster-local chart.
- `values.yaml` made generic: cluster-specifics (`dnsZone`, `mongoService.externalHost`, `router.name`, selectors) are blank/conservative defaults, supplied per-cluster via versionStream.
- README documents the manual NetBird runbook the operator can't manage (JWT account setting, one-policy-per-resource, optional DNS/domain resources).

Follow-ups (separate PRs): jx3-versions pin + values, then flip `kube-dev-ovh-sbg5` helmfile to `lop3z/netbird-access` and delete the local chart.