### PR TITLE
feat(netbird-secrets): publish chart (promoted from kube-dev cluster-local)

### DIFF
--- a/charts/netbird-secrets/Chart.yaml
+++ b/charts/netbird-secrets/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: netbird-secrets
+description: Vault-backed Secrets for self-hosted NetBird — operator API key (PAT) + control-plane (datastore encryption key, relay password) (DEV-123)
+type: application
+version: 0.1.0
+appVersion: 0.6.0

--- a/charts/netbird-secrets/templates/api-key-secret.yaml
+++ b/charts/netbird-secrets/templates/api-key-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.createApiKeySecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secretName }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  # Resolved at admission by vault-secrets-webhook.
+  NB_API_KEY: {{ .Values.vaultRef }}
+{{- end }}

--- a/charts/netbird-secrets/templates/control-plane-secret.yaml
+++ b/charts/netbird-secrets/templates/control-plane-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.controlPlaneSecretName }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  # Resolved at admission by vault-secrets-webhook; consumed as env by management + relay.
+{{- range $key, $ref := .Values.controlPlane }}
+  {{ $key }}: {{ $ref }}
+{{- end }}

--- a/charts/netbird-secrets/values.yaml
+++ b/charts/netbird-secrets/values.yaml
@@ -1,0 +1,14 @@
+# Operator API-key Secret — name/key must match netbirdAPI.keyFromSecret in the netbird-operator values.
+# Disabled until the NetBird service-user PAT exists in Vault (post-login bootstrap); enabled with
+# the operator release in a follow-up.
+createApiKeySecret: true
+secretName: netbird-mgmt-api-key
+# Vault path holding the NetBird management API key (PAT). Leading slash per repo convention.
+vaultRef: vault:/secret/data/netbird#NB_API_KEY
+
+# Control-plane Secret consumed (as env) by the management + relay pods and substituted into
+# management.json at runtime. Keys must match the netbird/netbird chart's envFromSecret refs.
+controlPlaneSecretName: netbird-cp-secrets
+controlPlane:
+  DATASTORE_ENCRYPTION_KEY: vault:/secret/data/netbird#DATASTORE_ENCRYPTION_KEY
+  RELAY_PASSWORD: vault:/secret/data/netbird#RELAY_PASSWORD


### PR DESCRIPTION
Promotes `netbird-secrets` out of `charts/` into helm-charts, so it's referenceable as `` (same pattern as netbird-access #14).