### PR TITLE
fix(kube-prometheus-rules): raise node load alert thresholds

### DIFF
--- a/charts/kube-prometheus-rules/Chart.yaml
+++ b/charts/kube-prometheus-rules/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-rules
 description: Community-inspired Prometheus alerting rules for Kubernetes observability (PVC, node, pod, disk)
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "1.0.0"
 maintainers:
   - name: lop3z

--- a/charts/kube-prometheus-rules/values.yaml
+++ b/charts/kube-prometheus-rules/values.yaml
@@ -63,8 +63,8 @@ rules:
     # Normalized load (load15 / cpu_count) thresholds.
     # Using the 15-minute average smooths out short spikes that don't reflect
     # sustained pressure on the node.
-    loadWarningRatio: 1.20
-    loadCriticalRatio: 1.50
+    loadWarningRatio: 1.50
+    loadCriticalRatio: 2.00
 
   workload:
     enabled: true


### PR DESCRIPTION
## Summary
- Raise `KubeNodeLoadHigh` thresholds: warning `1.20→1.50x`, critical `1.50→2.00x` normalized load 